### PR TITLE
Add SLF4J Logger Factory for JVM target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cz.lukynka"
-version = "1.8"
+version = "1.9"
 
 java.sourceCompatibility = JavaVersion.VERSION_17
 
@@ -29,6 +29,14 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(kotlin("test-common"))
+        }
+
+        jvmMain.dependencies {
+            api("org.slf4j:slf4j-api:2.0.17")
+        }
+
+        jvmTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 

--- a/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLogger.kt
+++ b/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLogger.kt
@@ -6,7 +6,7 @@ import org.slf4j.helpers.MessageFormatter
 
 // TODO Implement SLF4J Marker support.
 
-class PrettyLogger(name: String) : Logger {
+class PrettyLogger(val name: String) : Logger {
     override fun getName(): String = this.name
 
     //region Trace

--- a/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLogger.kt
+++ b/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLogger.kt
@@ -1,0 +1,201 @@
+package cz.lukynka.prettylog
+
+import org.slf4j.Logger
+import org.slf4j.Marker
+import org.slf4j.helpers.MessageFormatter
+
+// TODO Implement SLF4J Marker support.
+
+class PrettyLogger(name: String) : Logger {
+    override fun getName(): String = this.name
+
+    //region Trace
+    override fun isTraceEnabled(): Boolean = true
+
+    override fun trace(msg: String) = log(msg, LogType.TRACE)
+
+    override fun trace(format: String, arg: Any) = log(MessageFormatter.format(format, arg).message,  LogType.TRACE)
+
+    override fun trace(format: String, arg1: Any, arg2: Any) = log(MessageFormatter.format(format, arg1, arg2).message,  LogType.TRACE)
+
+    override fun trace(format: String, vararg arguments: Any) = log(MessageFormatter.format(format, arguments).message,  LogType.TRACE)
+
+    override fun trace(msg: String, t: Throwable?) = log(Exception(msg, t))
+
+    override fun isTraceEnabled(marker: Marker): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(marker: Marker, msg: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(marker: Marker, format: String, arg: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(marker: Marker, format: String, arg1: Any, arg2: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(marker: Marker, format: String, vararg argArray: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(marker: Marker, msg: String, t: Throwable) {
+        TODO("Not yet implemented")
+    }
+    //endregion
+
+    //region Debug
+    override fun isDebugEnabled(): Boolean = true
+
+    override fun debug(msg: String) = log(msg, LogType.DEBUG)
+
+    override fun debug(format: String, arg: Any) = log(MessageFormatter.format(format, arg).message, LogType.DEBUG)
+
+    override fun debug(format: String, arg1: Any, arg2: Any) = log(MessageFormatter.format(format, arg1, arg2).message, LogType.DEBUG)
+
+    override fun debug(format: String, vararg arguments: Any) = log(MessageFormatter.format(format, arguments).message, LogType.DEBUG)
+
+    override fun debug(msg: String, t: Throwable) = log(Exception(msg, t))
+
+    override fun isDebugEnabled(marker: Marker): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(marker: Marker, msg: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(marker: Marker, format: String, arg: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(marker: Marker, format: String, arg1: Any, arg2: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(marker: Marker, format: String, vararg arguments: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(marker: Marker, msg: String, t: Throwable) {
+        TODO("Not yet implemented")
+    }
+    //endregion
+
+    //region Info
+    override fun isInfoEnabled(): Boolean = true
+
+    override fun info(msg: String) = log(msg, LogType.INFORMATION)
+
+    override fun info(format: String, arg: Any) = log(MessageFormatter.format(format, arg).message, LogType.INFORMATION)
+
+    override fun info(format: String, arg1: Any, arg2: Any) = log(MessageFormatter.format(format, arg1, arg2).message, LogType.INFORMATION)
+
+    override fun info(format: String, vararg arguments: Any) = log(MessageFormatter.format(format, arguments).message, LogType.INFORMATION)
+
+    override fun info(msg: String, t: Throwable) = log(Exception(msg, t))
+
+    override fun isInfoEnabled(marker: Marker): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(marker: Marker, msg: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(marker: Marker, format: String, arg: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(marker: Marker, format: String, arg1: Any, arg2: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(marker: Marker, format: String, vararg arguments: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(marker: Marker, msg: String, t: Throwable) {
+        TODO("Not yet implemented")
+    }
+    //endregion
+
+    //region Warn
+    override fun isWarnEnabled(): Boolean = true
+
+    override fun warn(msg: String) = log(msg, LogType.WARNING)
+
+    override fun warn(format: String, arg: Any) = log(MessageFormatter.format(format, arg).message, LogType.WARNING)
+
+    override fun warn(format: String, vararg arguments: Any) = log(MessageFormatter.format(format, arguments).message, LogType.WARNING)
+
+    override fun warn(format: String, arg1: Any, arg2: Any) = log(MessageFormatter.format(format, arg1, arg2).message, LogType.WARNING)
+
+    override fun warn(msg: String, t: Throwable) = log(Exception(msg, t))
+
+    override fun isWarnEnabled(marker: Marker): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(marker: Marker, msg: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(marker: Marker, format: String, arg: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(marker: Marker, format: String, arg1: Any, arg2: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(marker: Marker, format: String, vararg arguments: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(marker: Marker, msg: String, t: Throwable) {
+        TODO("Not yet implemented")
+    }
+    //endregion
+
+    //region Error
+    override fun isErrorEnabled(): Boolean = true
+
+    override fun error(msg: String) = log(msg, LogType.ERROR)
+
+    override fun error(format: String, arg: Any) = log(MessageFormatter.format( format, arg).message, LogType.ERROR)
+
+    override fun error(format: String, arg1: Any, arg2: Any) = log(MessageFormatter.format( format, arg1, arg2).message, LogType.ERROR)
+
+    override fun error(format: String, vararg arguments: Any) = log(MessageFormatter.format(format, arguments).message, LogType.ERROR)
+
+    override fun error(msg: String, t: Throwable) = log(Exception(msg, t))
+
+    override fun isErrorEnabled(marker: Marker): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(marker: Marker, msg: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(marker: Marker, format: String, arg: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(marker: Marker, format: String, arg1: Any, arg2: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(marker: Marker, format: String, vararg arguments: Any) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(marker: Marker, msg: String, t: Throwable) {
+        TODO("Not yet implemented")
+    }
+    //endregion
+}

--- a/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLoggerFactory.kt
+++ b/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLoggerFactory.kt
@@ -1,0 +1,9 @@
+package cz.lukynka.prettylog
+
+import org.slf4j.ILoggerFactory
+import org.slf4j.Logger
+
+class PrettyLoggerFactory : ILoggerFactory {
+    override fun getLogger(name: String): Logger = PrettyLogger(name)
+
+}

--- a/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLoggerProvider.kt
+++ b/src/jvmMain/kotlin/cz/lukynka/prettylog/PrettyLoggerProvider.kt
@@ -1,0 +1,21 @@
+package cz.lukynka.prettylog
+
+import org.slf4j.ILoggerFactory
+import org.slf4j.IMarkerFactory
+import org.slf4j.helpers.NOPMDCAdapter
+import org.slf4j.spi.MDCAdapter
+import org.slf4j.spi.SLF4JServiceProvider
+
+class PrettyLoggerProvider : SLF4JServiceProvider {
+    private val REQUESTED_API_VERSION = "2.0.17"
+    private lateinit var prettyLoggerFactory: PrettyLoggerFactory
+
+    override fun getLoggerFactory(): ILoggerFactory = prettyLoggerFactory
+    override fun getMarkerFactory(): IMarkerFactory? = null
+    override fun getMDCAdapter(): MDCAdapter = NOPMDCAdapter()
+    override fun getRequestedApiVersion(): String = REQUESTED_API_VERSION
+
+    override fun initialize() {
+        prettyLoggerFactory =  PrettyLoggerFactory()
+    }
+}

--- a/src/jvmMain/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/src/jvmMain/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+cz.lukynka.prettylog.PrettyLoggerProvider

--- a/src/jvmTest/kotlin/cz/lukynka/prettylog/Slf4jTests.kt
+++ b/src/jvmTest/kotlin/cz/lukynka/prettylog/Slf4jTests.kt
@@ -1,0 +1,23 @@
+package cz.lukynka.prettylog
+
+import org.slf4j.LoggerFactory
+import kotlin.test.Test
+
+class Slf4jTests {
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    @Test
+    fun testTrace() = logger.trace("Testing trace() in Slf4jTests.")
+
+    @Test
+    fun testDebug() = logger.debug("Testing debug() in Slf4jTests.")
+
+    @Test
+    fun testInfo() = logger.info("Testing info() in Slf4jTests.")
+
+    @Test
+    fun testWarn() = logger.warn("Testing warn() in Slf4jTests.")
+
+    @Test
+    fun testError() = logger.error("Testing error() in Slf4jTests.")
+}


### PR DESCRIPTION
Implemented a SLF4J logging factory (minus markers) for use with anything that uses SLF4J, most notably, this now allows it to function with [JDA](https://github.com/discord-jda/JDA) :3